### PR TITLE
6 add archetype functions

### DIFF
--- a/asf_heat_pump_affordability/config/base.yaml
+++ b/asf_heat_pump_affordability/config/base.yaml
@@ -2,3 +2,16 @@ data_source:
   cpi_source_url: "https://www.ons.gov.uk/generator?format=csv&uri=/economy/inflationandpriceindices/timeseries/d7ck/mm23"
 cpi_data:
   cpi_column_header: "CPI INDEX 05.3 : Household appliances, fitting and repairs 2015=100"
+construction_age_band_1950_split:
+  "England and Wales: before 1900": True
+  "Scotland: before 1919": True
+  "1900-1929": True
+  "1930-1949": True
+  "1950-1966": False
+  "1965-1975": False
+  "1976-1983": False
+  "1983-1991": False
+  "1991-1998": False
+  "1996-2002": False
+  "2003-2007": False
+  "2007 onwards": False

--- a/asf_heat_pump_affordability/pipeline/archetypes.py
+++ b/asf_heat_pump_affordability/pipeline/archetypes.py
@@ -1,0 +1,102 @@
+import pandas as pd
+from asf_heat_pump_affordability import config
+
+
+def classify_dict_archetypes_masks(
+    df: pd.DataFrame,
+    ages_mapping: dict = config["construction_age_band_1950_split"],
+    year_label: str = "1950",
+) -> dict:
+    """
+    Generate dictionary where keys are property archetype labels and values are corresponding pandas Series of boolean
+    values which can be used to mask or filter the dataframe for the given archetype.
+
+    Produces eight property archetypes: flats; semi-detached & terraced houses and maisonettes; detached houses; and
+    bungalows; with each group split into 'pre' and 'post' groupings for a given construction year determined by
+    `ages_mapping`.
+
+    Args
+        df (pd.DataFrame): joined MCS-EPC dataframe containing property characteristics
+        ages_mapping (dict): dict mapping construction age bands to boolean values. Default dict where construction ages
+                             before 1950 are mapped to `True` and after 1950 to `False`.
+        year_label (str): bisecting year for 'pre' and 'post' construction age band groupings to label data with.
+                          Defaults to "1950".
+
+    Returns
+        dict: dictionary of archetype labels with corresponding pandas Series of boolean values
+
+    """
+    age_split = df["CONSTRUCTION_AGE_BAND"].map(ages_mapping)
+
+    masks = {}
+
+    # Flats
+    masks[f"pre_{year_label}_flat"] = (df["PROPERTY_TYPE"] == "Flat") & age_split
+    masks[f"post_{year_label}_flat"] = (df["PROPERTY_TYPE"] == "Flat") & (~age_split)
+
+    # Semi-detached & terraced houses, and maisonettes
+    masks[f"pre_{year_label}_semi_terraced_house"] = (
+        _classify_series_semi_terraced_house(df) & age_split
+    )
+    masks[
+        f"post_{year_label}_semi_terraced_house"
+    ] = _classify_series_semi_terraced_house(df) & (~age_split)
+
+    # Detached houses
+    masks[f"pre_{year_label}_detached_house"] = (
+        _classify_series_detached_house(df) & age_split
+    )
+    masks[f"post_{year_label}_detached_house"] = _classify_series_detached_house(df) & (
+        ~age_split
+    )
+
+    # Bungalows
+    masks[f"pre_{year_label}_bungalow"] = (
+        df["PROPERTY_TYPE"] == "Bungalow"
+    ) & age_split
+    masks[f"post_{year_label}_bungalow"] = (df["PROPERTY_TYPE"] == "Bungalow") & (
+        ~age_split
+    )
+
+    return masks
+
+
+def _classify_series_semi_terraced_house(df: pd.DataFrame) -> pd.Series:
+    """
+    Generate pandas Series of boolean values to classify whether or not properties are in the category of 'semi-detached
+    or terraced houses, or maisonettes'.
+
+    Args
+        df (pd.DataFrame): joined MCS-EPC dataframe containing property characteristics
+
+    Returns
+        pd.Series: boolean values where `True` indicates the property is a semi-detached or terraced house, or maisonette
+    """
+    mask = (df["PROPERTY_TYPE"] == "Maisonette") | (
+        (df["PROPERTY_TYPE"] == "House")
+        & (
+            df["BUILT_FORM"].isin(
+                [
+                    "Semi-Detached",
+                    "Mid-Terrace",
+                    "End-Terrace",
+                    "Enclosed End-Terrace",
+                    "Enclosed Mid-Terrace",
+                ]
+            )
+        )
+    )
+    return mask
+
+
+def _classify_series_detached_house(df: pd.DataFrame) -> pd.Series:
+    """
+    Generate pandas Series of boolean values to classify whether or not properties are detached houses.
+
+    Args
+        df (pd.DataFrame): joined MCS-EPC dataframe containing property characteristics
+
+    Returns
+        pd.Series: boolean values where `True` indicates the property is a detached house
+    """
+    return (df["PROPERTY_TYPE"] == "House") & (df["BUILT_FORM"] == "Detached")

--- a/asf_heat_pump_affordability/pipeline/generate_cost_percentiles.py
+++ b/asf_heat_pump_affordability/pipeline/generate_cost_percentiles.py
@@ -1,0 +1,91 @@
+import pandas as pd
+import numpy as np
+
+
+def generate_dict_cost_percentiles_by_archetype(
+    cost_series: pd.Series,
+    archetypes_masks: dict,
+    percentiles: list or np.array,
+) -> dict:
+    """
+    Generate dict with archetype name and values for cost at each given percentile for every archetype in `archetype_masks`.
+
+    Args
+        cost_series (pd.Series): series of (adjusted) cost values
+        archetype_masks (dict): dictionary of archetype labels with corresponding pandas Series of boolean values
+        percentiles (list or np.array): percentile(s) at which to extract cost values (range 0 to 1)
+
+    Returns
+        dict: where archetype names are keys and array of cost values at given percentile(s) are values
+    """
+    archetype_costs_dict = {}
+    for archetype_name, archetype_mask in archetypes_masks.items():
+        archetype_costs_dict[archetype_name] = (
+            cost_series[archetype_mask].quantile(percentiles).values
+        )
+
+    return archetype_costs_dict
+
+
+def generate_df_cost_percentiles_by_archetype_formatted(
+    archetype_costs_dict: dict, percentiles: list or np.array, ref_year: int
+) -> pd.DataFrame:
+    """
+    Convert dict of archetype costs to dataframe.
+
+    Args
+        archetype_costs_dict (dict): where archetype names are keys and array of cost values at given percentile(s) are values
+        percentiles (list or np.array): percentile(s) at which cost values have been extracted (range 0 to 1)
+        ref_year (int): reference year for adjusted costs
+
+    Returns:
+        pd.DataFrame: cost percentiles by property archetype
+
+    """
+    _cols = _generate_list_column_names(percentiles=percentiles, ref_year=ref_year)
+    _cols.insert(0, "property_archetype")
+
+    df = pd.DataFrame(archetype_costs_dict).T.reset_index()
+    df.columns = _cols
+    df = df.set_index("property_archetype").applymap(_round_cost)
+
+    return df
+
+
+def _round_cost(v):
+    """
+    Args v: int or float
+    Returns int: value rounded to nearest 10
+    """
+    return int(round(v, -1))
+
+
+def _generate_list_column_names(percentiles, ref_year):
+    """
+    Create list of string column names from percentiles
+
+    Args
+        percentiles (list or np.array): percentile(s) at which cost values have been extracted (range 0 to 1)
+        cpi_data_year (int): reference year for adjusted costs
+
+    Returns
+        list: column names
+    """
+    columns = []
+    mapping = {
+        0: "min",
+        0.25: "lower_quartile",
+        0.5: "median",
+        0.75: "upper_quartile",
+        1: "max",
+    }
+
+    for pc in percentiles:
+        if pc in [0, 0.25, 0.5, 0.75, 1]:
+            columns.append(mapping[pc])
+        else:
+            columns.append(f"{int(pc * 100)}th_percentile")
+
+    columns = ["_".join([col, "adjusted_cost", str(ref_year)]) for col in columns]
+
+    return columns

--- a/asf_heat_pump_affordability/pipeline/generate_cost_percentiles.py
+++ b/asf_heat_pump_affordability/pipeline/generate_cost_percentiles.py
@@ -1,11 +1,12 @@
 import pandas as pd
 import numpy as np
+from typing import Iterable
 
 
 def generate_dict_cost_quantiles_by_archetype(
     cost_series: pd.Series,
     archetypes_masks: dict,
-    quantiles: list or np.array,
+    quantiles: Iterable[float],
 ) -> dict:
     """
     Generate dict where property archetype names from `archetype_masks` are keys and arrays of cost values at given quantile(s) are values.
@@ -13,7 +14,7 @@ def generate_dict_cost_quantiles_by_archetype(
     Args
         cost_series (pd.Series): series of (adjusted) cost values
         archetype_masks (dict): dictionary of archetype labels with corresponding pandas Series of boolean values
-        quantiles (list or np.array): quantile(s) at which to extract cost values (range 0 to 1)
+        quantiles (Iterable[float]): quantile(s) at which to extract cost values (range 0 to 1)
 
     Returns
         dict: {(str) archetype_name: (np.array) cost values at given quantile(s)}
@@ -28,14 +29,14 @@ def generate_dict_cost_quantiles_by_archetype(
 
 
 def generate_df_cost_percentiles_by_archetype_formatted(
-    archetype_costs_dict: dict, quantiles: list or np.array, ref_year: int
+    archetype_costs_dict: dict, quantiles: Iterable[float], ref_year: int
 ) -> pd.DataFrame:
     """
     Convert dict of archetype costs to dataframe.
 
     Args
         archetype_costs_dict (dict): where archetype names are keys and array of cost values at given quantile(s) are values
-        quantiles (list or np.array): quantile(s) at which cost values have been extracted (range 0 to 1)
+        quantiles (Iterable[float]): quantile(s) at which cost values have been extracted (range 0 to 1)
         ref_year (int): reference year for adjusted costs
 
     Returns:
@@ -65,7 +66,7 @@ def _generate_list_column_names(quantiles, ref_year):
     Create list of string column names from quantiles
 
     Args
-        quantiles (list or np.array): quantile(s) at which cost values have been extracted (range 0 to 1)
+        quantiles (Iterable[float]): quantile(s) at which cost values have been extracted (range 0 to 1)
         cpi_data_year (int): reference year for adjusted costs
 
     Returns

--- a/asf_heat_pump_affordability/pipeline/generate_cost_percentiles.py
+++ b/asf_heat_pump_affordability/pipeline/generate_cost_percentiles.py
@@ -2,47 +2,47 @@ import pandas as pd
 import numpy as np
 
 
-def generate_dict_cost_percentiles_by_archetype(
+def generate_dict_cost_quantiles_by_archetype(
     cost_series: pd.Series,
     archetypes_masks: dict,
-    percentiles: list or np.array,
+    quantiles: list or np.array,
 ) -> dict:
     """
-    Generate dict with archetype name and values for cost at each given percentile for every archetype in `archetype_masks`.
+    Generate dict where property archetype names from `archetype_masks` are keys and arrays of cost values at given quantile(s) are values.
 
     Args
         cost_series (pd.Series): series of (adjusted) cost values
         archetype_masks (dict): dictionary of archetype labels with corresponding pandas Series of boolean values
-        percentiles (list or np.array): percentile(s) at which to extract cost values (range 0 to 1)
+        quantiles (list or np.array): quantile(s) at which to extract cost values (range 0 to 1)
 
     Returns
-        dict: where archetype names are keys and array of cost values at given percentile(s) are values
+        dict: {(str) archetype_name: (np.array) cost values at given quantile(s)}
     """
     archetype_costs_dict = {}
     for archetype_name, archetype_mask in archetypes_masks.items():
         archetype_costs_dict[archetype_name] = (
-            cost_series[archetype_mask].quantile(percentiles).values
+            cost_series[archetype_mask].quantile(quantiles).values
         )
 
     return archetype_costs_dict
 
 
 def generate_df_cost_percentiles_by_archetype_formatted(
-    archetype_costs_dict: dict, percentiles: list or np.array, ref_year: int
+    archetype_costs_dict: dict, quantiles: list or np.array, ref_year: int
 ) -> pd.DataFrame:
     """
     Convert dict of archetype costs to dataframe.
 
     Args
-        archetype_costs_dict (dict): where archetype names are keys and array of cost values at given percentile(s) are values
-        percentiles (list or np.array): percentile(s) at which cost values have been extracted (range 0 to 1)
+        archetype_costs_dict (dict): where archetype names are keys and array of cost values at given quantile(s) are values
+        quantiles (list or np.array): quantile(s) at which cost values have been extracted (range 0 to 1)
         ref_year (int): reference year for adjusted costs
 
     Returns:
         pd.DataFrame: cost percentiles by property archetype
 
     """
-    _cols = _generate_list_column_names(percentiles=percentiles, ref_year=ref_year)
+    _cols = _generate_list_column_names(quantiles=quantiles, ref_year=ref_year)
     _cols.insert(0, "property_archetype")
 
     df = pd.DataFrame(archetype_costs_dict).T.reset_index()
@@ -60,12 +60,12 @@ def _round_cost(v):
     return int(round(v, -1))
 
 
-def _generate_list_column_names(percentiles, ref_year):
+def _generate_list_column_names(quantiles, ref_year):
     """
-    Create list of string column names from percentiles
+    Create list of string column names from quantiles
 
     Args
-        percentiles (list or np.array): percentile(s) at which cost values have been extracted (range 0 to 1)
+        quantiles (list or np.array): quantile(s) at which cost values have been extracted (range 0 to 1)
         cpi_data_year (int): reference year for adjusted costs
 
     Returns
@@ -80,11 +80,11 @@ def _generate_list_column_names(percentiles, ref_year):
         1: "max",
     }
 
-    for pc in percentiles:
-        if pc in [0, 0.25, 0.5, 0.75, 1]:
-            columns.append(mapping[pc])
+    for q in quantiles:
+        if q in [0, 0.25, 0.5, 0.75, 1]:
+            columns.append(mapping[q])
         else:
-            columns.append(f"{int(pc * 100)}th_percentile")
+            columns.append(f"{int(q * 100)}th_percentile")
 
     columns = ["_".join([col, "adjusted_cost", str(ref_year)]) for col in columns]
 

--- a/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
+++ b/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
@@ -56,8 +56,7 @@ def run():
     parser.add_argument(
         "--save_to_s3",
         help="Save sample and output datasets to `asf-heat-pump-affordability` S3 bucket.",
-        type=bool,
-        default=True,
+        action="store_true",
     )
 
     args = parser.parse_args()
@@ -73,7 +72,9 @@ def main(
     save_to_s3: bool = True,
 ) -> pd.DataFrame:
     """
-    IN DEV: currently imports MCS-EPC joined dataset, applies exclusion criteria to it and saves the output to S3.
+    Import MCS-EPC joined dataset, apply preprocessing, and calculate specified cost percentiles (adjusted for inflation
+    against a given base year) for MCS-certified installations of Air Source Heat Pumps (ASHP) in eight different property
+    archetypes, where ASHPs were installed within the given year range.
 
     Args:
         mcs_epc_join_date (int): which batch of most_relevant joined MCS-EPC dataset to use, by date in the format YYMMDD.

--- a/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
+++ b/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
@@ -1,8 +1,14 @@
 import pandas as pd
+import numpy as np
 from argparse import ArgumentParser
 from typing import Optional
 from asf_heat_pump_affordability import config, json_schema
-from asf_heat_pump_affordability.pipeline import preprocess_data, preprocess_cpi
+from asf_heat_pump_affordability.pipeline import (
+    archetypes,
+    preprocess_data,
+    preprocess_cpi,
+    generate_cost_percentiles,
+)
 from asf_heat_pump_affordability.getters import get_data
 
 
@@ -13,28 +19,45 @@ def run():
     parser = ArgumentParser()
     parser.add_argument(
         "--mcs_epc_join_date",
-        help="Specify which batch of most_relevant joined MCS-EPC dataset to use, by date in the format YYMMDD.",
+        help="Specify which batch of `most_relevant` joined MCS-EPC dataset to use, by date in the format YYMMDD.",
         type=int,
+        required=True,
     )
 
     parser.add_argument(
         "--cost_year_min",
         help="Min year of heat pump installation cost data to include in analysis. Default min year in dataset.",
-        default=None,
         type=int,
+        default=None,
     )
 
     parser.add_argument(
         "--cost_year_max",
         help="Max year of heat pump installation cost data to include in analysis. Default max year in dataset.",
-        default=None,
         type=int,
+        default=None,
     )
 
     parser.add_argument(
         "--cpi_data_year",
         help="Reference year to adjust heat pump installation costs to.",
         type=int,
+        required=True,
+    )
+
+    parser.add_argument(
+        "--cost_percentiles",
+        help="Percentile(s) at which to extract cost values for each property archetype (range 0 to 1).",
+        nargs="+",
+        type=float,
+        default=None,
+    )
+
+    parser.add_argument(
+        "--save_to_s3",
+        help="Save sample and output datasets to `asf-heat-pump-affordability` S3 bucket.",
+        type=bool,
+        default=True,
     )
 
     args = parser.parse_args()
@@ -46,6 +69,8 @@ def main(
     cpi_data_year: int,
     cost_year_min: Optional[int] = None,
     cost_year_max: Optional[int] = None,
+    cost_percentiles: Optional[list or np.array] = None,
+    save_to_s3: bool = True,
 ) -> pd.DataFrame:
     """
     IN DEV: currently imports MCS-EPC joined dataset, applies exclusion criteria to it and saves the output to S3.
@@ -55,11 +80,11 @@ def main(
         cpi_data_year (int): reference year to adjust heat pump installation costs to
         cost_year_min (int): min year of heat pump installation cost data to include in analysis
         cost_year_max (int): max year of heat pump installation cost data to include in analysis
+        cost_percentiles (list or np.array): percentile(s) to get cost by archetype for
+        save_to_s3 (bool): save analytical sample and output dataset to asf-heat-pump-affordability bucket on S3. Defaults to True.
 
     Returns
-        IN DEV
-            target return: Excel file containing cost deciles by property archetype (save to S3)
-            currently returns: analytical sample dataset with adjusted costs
+        pd.DataFrame: cost percentiles for each property archetype adjusted for inflation
     """
     # Import MCS-EPC data
     mcs_epc_data = pd.read_csv(
@@ -71,14 +96,6 @@ def main(
     # Preprocess MCS-EPC data - apply exclusion criteria
     sample = preprocess_data.apply_exclusion_criteria(
         df=mcs_epc_data, cost_year_min=cost_year_min, cost_year_max=cost_year_max
-    )
-
-    # Save analytical sample
-    year_range = "".join(
-        [str(sample["commission_year"].min()), str(sample["commission_year"].max())]
-    )
-    sample.to_csv(
-        f"s3://asf-heat-pump-affordability/mcs_installations_epc_most_relevant_{mcs_epc_join_date}_preprocessed_yearRange_{year_range}.csv"
     )
 
     # Import and process CPI data
@@ -94,7 +111,50 @@ def main(
         mcs_epc_df=sample, cpi_quarters_df=cpi_quarterly_df
     )
 
-    return mcs_epc_inf
+    # Get archetypes
+    archetypes_dict = archetypes.classify_dict_archetypes_masks(mcs_epc_inf)
+
+    # Get cost percentiles
+    if not cost_percentiles:
+        cost_percentiles = np.arange(0, 1.1, 0.1)
+    archetypes_costs_dict = (
+        generate_cost_percentiles.generate_dict_cost_percentiles_by_archetype(
+            cost_series=mcs_epc_inf["adjusted_cost"],
+            archetypes_masks=archetypes_dict,
+            percentiles=cost_percentiles,
+        )
+    )
+    archetypes_costs_df = (
+        generate_cost_percentiles.generate_df_cost_percentiles_by_archetype_formatted(
+            archetype_costs_dict=archetypes_costs_dict,
+            percentiles=cost_percentiles,
+            ref_year=cpi_data_year,
+        )
+    )
+
+    # Save files to S3 bucket
+    if save_to_s3:
+        year_range = "".join(
+            [str(sample["commission_year"].min()), str(sample["commission_year"].max())]
+        )
+        ym_range = "_".join(
+            [
+                sample["commission_date"].dt.strftime("%Y%m").min(),
+                sample["commission_date"].dt.strftime("%Y%m").max(),
+            ]
+        )
+
+        # Save analytical sample
+        sample.to_csv(
+            f"s3://asf-heat-pump-affordability/mcs_installations_epc_most_relevant_{mcs_epc_join_date}_preprocessed_yearRange_{year_range}.csv"
+        )
+
+        # Save output
+        archetypes_costs_df.to_excel(
+            f"s3://asf-heat-pump-affordability/inflation_adjusted_costs_GBP_by_property_archetype_{cpi_data_year}_ashp_mcs_installations_{ym_range}.xlsx"
+        )
+
+    return archetypes_costs_df
 
 
 if __name__ == "__main__":

--- a/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
+++ b/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 from argparse import ArgumentParser
-from typing import Optional
+from typing import Optional, Iterable
 from asf_heat_pump_affordability import config, json_schema
 from asf_heat_pump_affordability.pipeline import (
     archetypes,
@@ -68,7 +68,7 @@ def main(
     cpi_data_year: int,
     cost_year_min: Optional[int] = None,
     cost_year_max: Optional[int] = None,
-    cost_quantiles: Optional[list or np.array] = None,
+    cost_quantiles: Optional[Iterable[float]] = None,
     save_to_s3: bool = True,
 ) -> pd.DataFrame:
     """
@@ -81,7 +81,8 @@ def main(
         cpi_data_year (int): reference year to adjust heat pump installation costs to
         cost_year_min (int): min year of heat pump installation cost data to include in analysis
         cost_year_max (int): max year of heat pump installation cost data to include in analysis
-        cost_quantiles (list or np.array): quantile(s) at which to extract cost values for each property archetype (range 0 to 1)
+        cost_quantiles (Iterable[float]): quantile(s) at which to extract cost values for each property archetype (range 0 to 1).
+                                          Default produces cost deciles.
         save_to_s3 (bool): save analytical sample and output dataset to `asf-heat-pump-affordability` bucket on S3. Default True.
 
     Returns
@@ -116,7 +117,7 @@ def main(
     archetypes_dict = archetypes.classify_dict_archetypes_masks(mcs_epc_inf)
 
     # Get cost quantiles
-    if not cost_quantiles:
+    if cost_quantiles is None:
         cost_quantiles = np.arange(0, 1.1, 0.1)
     archetypes_costs_dict = (
         generate_cost_percentiles.generate_dict_cost_quantiles_by_archetype(

--- a/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
+++ b/asf_heat_pump_affordability/pipeline/produce_costs_dataset.py
@@ -46,8 +46,8 @@ def run():
     )
 
     parser.add_argument(
-        "--cost_percentiles",
-        help="Percentile(s) at which to extract cost values for each property archetype (range 0 to 1).",
+        "--cost_quantiles",
+        help="Quantile(s) at which to extract cost values for each property archetype (range 0 to 1).",
         nargs="+",
         type=float,
         default=None,
@@ -69,7 +69,7 @@ def main(
     cpi_data_year: int,
     cost_year_min: Optional[int] = None,
     cost_year_max: Optional[int] = None,
-    cost_percentiles: Optional[list or np.array] = None,
+    cost_quantiles: Optional[list or np.array] = None,
     save_to_s3: bool = True,
 ) -> pd.DataFrame:
     """
@@ -80,8 +80,8 @@ def main(
         cpi_data_year (int): reference year to adjust heat pump installation costs to
         cost_year_min (int): min year of heat pump installation cost data to include in analysis
         cost_year_max (int): max year of heat pump installation cost data to include in analysis
-        cost_percentiles (list or np.array): percentile(s) to get cost by archetype for
-        save_to_s3 (bool): save analytical sample and output dataset to asf-heat-pump-affordability bucket on S3. Defaults to True.
+        cost_quantiles (list or np.array): quantile(s) at which to extract cost values for each property archetype (range 0 to 1)
+        save_to_s3 (bool): save analytical sample and output dataset to `asf-heat-pump-affordability` bucket on S3. Default True.
 
     Returns
         pd.DataFrame: cost percentiles for each property archetype adjusted for inflation
@@ -114,20 +114,20 @@ def main(
     # Get archetypes
     archetypes_dict = archetypes.classify_dict_archetypes_masks(mcs_epc_inf)
 
-    # Get cost percentiles
-    if not cost_percentiles:
-        cost_percentiles = np.arange(0, 1.1, 0.1)
+    # Get cost quantiles
+    if not cost_quantiles:
+        cost_quantiles = np.arange(0, 1.1, 0.1)
     archetypes_costs_dict = (
-        generate_cost_percentiles.generate_dict_cost_percentiles_by_archetype(
+        generate_cost_percentiles.generate_dict_cost_quantiles_by_archetype(
             cost_series=mcs_epc_inf["adjusted_cost"],
             archetypes_masks=archetypes_dict,
-            percentiles=cost_percentiles,
+            quantiles=cost_quantiles,
         )
     )
     archetypes_costs_df = (
         generate_cost_percentiles.generate_df_cost_percentiles_by_archetype_formatted(
             archetype_costs_dict=archetypes_costs_dict,
-            percentiles=cost_percentiles,
+            quantiles=cost_quantiles,
             ref_year=cpi_data_year,
         )
     )


### PR DESCRIPTION
Addresses #6 

# Description

Summary of changes:
- add archetypes functions to classify properties into 8 given archetypes
- add functions to generate cost quantiles and create a clean final output dataframe of cost percentiles by property archetype
- update main() and run() functions to use the new functions listed above and produce basic target output of dataframe and excel file (saved to S3) of adjusted cost percentiles by property archetype

NB I will add a descriptive README in a separate PR.

# Instructions for Reviewer

Please could you:
- general check for errors and issues
- test the code runs for you with any flags you want from the args. This is the line that I used to produce a test file that's saved to S3 `python asf_heat_pump_affordability/pipeline/produce_costs_dataset.py --mcs_epc_join_date 231009 --cost_year_min 2021 --cpi_data_year 2023 --cost_quantiles 0 0.25 0.5 0.75 1 --save_to_s3`
- leave off `--save_to_s3` flag if not wanting to save to s3
- you can also test by importing `main()` as before. I have also checked this works for me.
- please let me know if you have any ideas to further streamline the `classify_dict_archetypes_masks` function. I've left a comment on the file to explain my choices.
- let me know if you think the functions in `generate_cost_percentiles.py` are too prescriptive

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
