### PR TITLE
12 add imd income deciles

### DIFF
--- a/asf_heat_pump_affordability/config/base.yaml
+++ b/asf_heat_pump_affordability/config/base.yaml
@@ -3,6 +3,8 @@ data_source:
   gb_off_gas_postcodes_url: "https://www.xoserve.com/media/ey2lwltm/off_gas_postcode_register_oct_2023_v3_2.xlsx" # Oct 2023 data
   gb_ons_postcode_dir_url: "https://www.arcgis.com/sharing/rest/content/items/487a5ba62c8b4da08f01eb3c08e304f6/data" # Aug 2023 data
   gb_ons_postcode_dir_file_path: "Data/ONSPD_AUG_2023_UK.csv" # Aug 2023 data
+  engwal_imd_income_url: "https://assets.publishing.service.gov.uk/media/5fca57d2e90e0762aabe9444/2019_Income_and_Employment_Domains_-_England_and_Wales.ods" # IMD 2019
+  sct_imd_income_url: "https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2020/01/scottish-index-of-multiple-deprivation-2020-ranks-and-domain-ranks/documents/scottish-index-of-multiple-deprivation-2020-ranks-and-domain-ranks/scottish-index-of-multiple-deprivation-2020-ranks-and-domain-ranks/govscot%3Adocument/SIMD%2B2020v2%2B-%2Branks.xlsx" # IMD 2020v2
 cpi_data:
   cpi_column_header: "CPI INDEX 05.3 : Household appliances, fitting and repairs 2015=100"
 construction_age_band_1950_split:

--- a/asf_heat_pump_affordability/getters/get_data.py
+++ b/asf_heat_pump_affordability/getters/get_data.py
@@ -73,6 +73,58 @@ def _get_content_from_url(url: str) -> BytesIO:
     return content
 
 
+def get_df_imd_income_deciles_engwal(sheet_name: str = "Income") -> pd.DataFrame:
+    """
+    Get dataframe of income deprivation rank deciles for LSOAs in England and Wales.
+
+    Args
+        sheet_name (str): name of sheet where income deprivation data is stored in file
+
+    Returns
+        pd.DataFrame: income rank deciles by LSOA code for England and Wales
+    """
+    df = get_df_from_excel_url(
+        config["data_source"]["engwal_imd_income_url"], sheet_name=sheet_name
+    )
+    df["engwal_imd_income_rank_decile"] = pd.qcut(
+        df["Income Domain Rank (where 1 is most deprived)"],
+        10,
+        labels=np.arange(1, 11, 1),
+    )
+    df = df[
+        [
+            "LSOA Code (2011)",
+            "Income Domain Rank (where 1 is most deprived)",
+            "engwal_imd_income_rank_decile",
+        ]
+    ]
+    return df
+
+
+def get_df_imd_income_deciles_sct(
+    sheet_name: str = "SIMD 2020v2 ranks",
+) -> pd.DataFrame:
+    """
+    Get dataframe of income deprivation rank deciles for Data Zones in Scotland.
+
+    Args
+        sheet_name (str): name of sheet where income deprivation data is stored in file
+
+    Returns
+        pd.DataFrame: income rank deciles by Data Zone for Scotland
+    """
+    df = get_df_from_excel_url(
+        config["data_source"]["sct_imd_income_url"], sheet_name=sheet_name
+    )
+    df["sct_imd_income_rank_decile"] = pd.qcut(
+        df["SIMD2020v2_Income_Domain_Rank"], 10, labels=np.arange(1, 11, 1)
+    )
+    df = df[
+        ["Data_Zone", "SIMD2020v2_Income_Domain_Rank", "sct_imd_income_rank_decile"]
+    ]
+    return df
+
+
 def get_list_off_gas_postcodes(sheet_name: str = "Off-Gas Postcodes 2023") -> list:
     """
     Get list of off-gas postcodes in Great Britain.

--- a/asf_heat_pump_affordability/getters/get_data.py
+++ b/asf_heat_pump_affordability/getters/get_data.py
@@ -81,7 +81,7 @@ def get_df_imd_income_deciles_engwal(sheet_name: str = "Income") -> pd.DataFrame
         sheet_name (str): name of sheet where income deprivation data is stored in file
 
     Returns
-        pd.DataFrame: income rank deciles by LSOA code for England and Wales
+        pd.DataFrame: income deprivation rank deciles by LSOA code for England and Wales
     """
     df = get_df_from_excel_url(
         config["data_source"]["engwal_imd_income_url"], sheet_name=sheet_name
@@ -111,7 +111,7 @@ def get_df_imd_income_deciles_sct(
         sheet_name (str): name of sheet where income deprivation data is stored in file
 
     Returns
-        pd.DataFrame: income rank deciles by Data Zone for Scotland
+        pd.DataFrame: income deprivation rank deciles by Data Zone for Scotland
     """
     df = get_df_from_excel_url(
         config["data_source"]["sct_imd_income_url"], sheet_name=sheet_name

--- a/asf_heat_pump_affordability/pipeline/preprocess_data.py
+++ b/asf_heat_pump_affordability/pipeline/preprocess_data.py
@@ -51,7 +51,8 @@ def apply_exclusion_criteria(
 
 def join_df_supplementary_variables(mcs_epc_df: pd.DataFrame) -> pd.DataFrame:
     """
-    Join supplementary variables to MCS-EPC data: rural-urban classification and off-gas status of properties.
+    Join supplementary variables to MCS-EPC data: rural-urban classification; off-gas status; and Index of Multiple
+    Deprivation (IMD) income deciles for England and Wales.
     Args
         mcs_epc_df (pd.DataFrame): joined MCS-EPC dataframe
     Returns
@@ -59,8 +60,14 @@ def join_df_supplementary_variables(mcs_epc_df: pd.DataFrame) -> pd.DataFrame:
     """
     off_gas_postcodes_list = get_data.get_list_off_gas_postcodes()
     ons_pd_df = get_data.get_df_onspd_gb()
+    engwal_imd_df = get_data.get_df_imd_income_deciles_engwal()
+    sct_imd_df = get_data.get_df_imd_income_deciles_sct()
 
-    df = mcs_epc_df.merge(ons_pd_df, how="left", on="postcode")
+    df = (
+        mcs_epc_df.merge(ons_pd_df, how="left", on="postcode")
+        .merge(engwal_imd_df, how="left", left_on="lsoa11", right_on="LSOA Code (2011)")
+        .merge(sct_imd_df, how="left", left_on="lsoa11", right_on="Data_Zone")
+    )
     df["off_gas"] = df["postcode"].isin(off_gas_postcodes_list)
 
     return df

--- a/asf_heat_pump_affordability/pipeline/preprocess_data.py
+++ b/asf_heat_pump_affordability/pipeline/preprocess_data.py
@@ -52,11 +52,11 @@ def apply_exclusion_criteria(
 def join_df_supplementary_variables(mcs_epc_df: pd.DataFrame) -> pd.DataFrame:
     """
     Join supplementary variables to MCS-EPC data: rural-urban classification; off-gas status; and Index of Multiple
-    Deprivation (IMD) income deciles for England and Wales.
+    Deprivation (IMD) income deprivation rank deciles for England and Wales.
     Args
         mcs_epc_df (pd.DataFrame): joined MCS-EPC dataframe
     Returns
-        pd.DataFrame: MCS-EPC data with off-gas and rural-urban classification variables
+        pd.DataFrame: MCS-EPC data with off-gas; rural-urban classification; and IMD income deprivation rank decile variables
     """
     off_gas_postcodes_list = get_data.get_list_off_gas_postcodes()
     ons_pd_df = get_data.get_df_onspd_gb()


### PR DESCRIPTION
Addresses #12 

# Description

- Add getters to get IMD income data and calculate deciles for Scotland and England & Wales. I have used the [2019 IMD combined data for England and Wales](https://www.gov.uk/government/statistics/indices-of-deprivation-2019-income-and-employment-domains-combined-for-england-and-wales), and the [2020v2 Scottish IMD data](https://www.gov.scot/collections/scottish-index-of-multiple-deprivation-2020/) for Scotland.
- Join IMD income data to sample MCS-EPC dataset

# Instructions for Reviewer

To run the code:
`python asf_heat_pump_affordability/pipeline/produce_costs_dataset.py --mcs_epc_join_date 231009 --cost_year_min 2021 --cpi_data_year 2023 --save_to_s3`

Please could you:
- Check workings to calculate income rank deciles are correct
- General review for errors or bad practice

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
