### PR TITLE
28 cost brackets

### DIFF
--- a/asf_heat_pump_affordability/notebooks/cost_brackets_ASHPs.py
+++ b/asf_heat_pump_affordability/notebooks/cost_brackets_ASHPs.py
@@ -126,23 +126,24 @@ mcs_df["country"].value_counts(dropna=False)
 
 # %%
 # UK-wide results
-uk_results = mcs_df["adjusted_cost_band"].value_counts().reset_index()
-uk_results["UK_percentage_of_installations"] = (
-    uk_results["count"] / uk_results["count"].sum() * 100
+results = mcs_df["adjusted_cost_band"].value_counts().reset_index()
+results["UK_percentage_of_installations"] = (
+    results["count"] / results["count"].sum() * 100
 ).round(2)
-uk_results = uk_results.rename(columns={"count": "UK_ASHP_installation_count"})
+results = results.rename(columns={"count": "UK_ASHP_installation_count"})
 
 # %%
-# Filter to Wales only
-wales_results = mcs_df[mcs_df["country"] == "Wales"]
-wales_results = wales_results["adjusted_cost_band"].value_counts().reset_index()
-wales_results["Wales_percentage_of_installations"] = (
-    wales_results["count"] / wales_results["count"].sum() * 100
-).round(2)
-wales_results = wales_results.rename(columns={"count": "Wales_ASHP_installation_count"})
+# Filter to each nation
+for country in ["England", "Scotland", "Wales"]:
+    df = mcs_df[mcs_df["country"] == country]
+    df = df["adjusted_cost_band"].value_counts().reset_index()
+    df[f"{country}_percentage_of_installations"] = (
+        df["count"] / df["count"].sum() * 100
+    ).round(2)
+    df = df.rename(columns={"count": f"{country}_ASHP_installation_count"})
+    results = results.merge(df, how="left", on="adjusted_cost_band")
 
 # %%
-results = wales_results.merge(uk_results, how="left", on="adjusted_cost_band")
 results["adjusted_cost_band"] = pd.Categorical(
     results["adjusted_cost_band"], categories=choices
 )
@@ -153,3 +154,5 @@ results
 results.to_csv(
     "s3://asf-heat-pump-affordability/May2022_March2024_ASHP_domestic_installation_costs_2024GBP.csv"
 )
+
+# %%

--- a/asf_heat_pump_affordability/notebooks/cost_brackets_ASHPs.py
+++ b/asf_heat_pump_affordability/notebooks/cost_brackets_ASHPs.py
@@ -1,0 +1,155 @@
+# %% [markdown]
+# ## Counts and percentages of domestic ASHP installations across cost brackets
+#
+# This notebook fulfils a data request from ASF team for a breakdown of the costs of domestic installations of heat pumps, in cost brackets, with a distribution of installations (number and percentage if possible) across these cost brackets since the launch of BUS, in Wales and in the UK (since May 2022).
+
+# %%
+import pandas as pd
+import numpy as np
+
+from asf_heat_pump_affordability import config
+from asf_heat_pump_affordability.getters import get_data
+from asf_heat_pump_affordability.pipeline import preprocess_data, preprocess_cpi
+
+# %% [markdown]
+# ## Load MCS data
+
+# %%
+cols = ["commission_date", "postcode", "tech_type", "installation_type", "cost"]
+
+# %%
+mcs_df = pd.read_csv(
+    "s3://asf-core-data/outputs/MCS/mcs_installations_241113.csv", usecols=cols
+)
+
+# %%
+mcs_df.head()
+
+# %%
+# Check when last record is from
+mcs_df["commission_date"].max()
+
+# %%
+# Filter to May 2022 onwards
+mcs_df = mcs_df[(mcs_df["commission_date"] >= "2022-05-01")]
+
+# %%
+# Check NA in each key column. Fine to drop these records
+mcs_df[["tech_type", "installation_type", "cost"]].isna().sum()
+
+# %%
+# See how installation type is coded
+mcs_df["installation_type"].value_counts(dropna=False)
+
+# %%
+# Filter data to relevant records
+mcs_df = mcs_df[
+    (mcs_df["tech_type"] == "Air Source Heat Pump")
+    & (mcs_df["installation_type"] == "Domestic")
+    & (~mcs_df["cost"].isna())
+]
+
+# %% [markdown]
+# ## Adjust cost data to 2024 average and add bands
+
+# %%
+# CPI data
+cpi_05_3_df = get_data.get_df_from_csv_url(config["data_source"]["cpi_source_url"])
+
+# %%
+# Get adjustment factors
+cpi_quarterly_df = preprocess_cpi.get_df_quarterly_cpi_with_adjustment_factors(
+    ref_year=2024,
+    cpi_df=cpi_05_3_df,
+    cpi_col_header=config["cpi_data"]["cpi_column_header"],
+)
+
+# %%
+mcs_df = preprocess_data.generate_df_adjusted_costs(
+    mcs_epc_df=mcs_df, cpi_quarters_df=cpi_quarterly_df
+)
+
+# %%
+# Add cost bands
+conditions = [
+    mcs_df["adjusted_cost"] <= 3000,
+    (mcs_df["adjusted_cost"] > 3000) & (mcs_df["adjusted_cost"] <= 6000),
+    (mcs_df["adjusted_cost"] > 6000) & (mcs_df["adjusted_cost"] <= 9000),
+    (mcs_df["adjusted_cost"] > 9000) & (mcs_df["adjusted_cost"] <= 12000),
+    (mcs_df["adjusted_cost"] > 12000) & (mcs_df["adjusted_cost"] <= 15000),
+    mcs_df["adjusted_cost"] > 15000,
+]
+
+choices = [
+    "£0-3000",
+    "£3001-6000",
+    "£6001-9000",
+    "£9001-12,000",
+    "£12,001-£15,0000",
+    "£15,001+",
+]
+
+mcs_df["adjusted_cost_band"] = np.select(conditions, choices)
+
+# %% [markdown]
+# ## Add country column with ONSPD
+
+# %%
+onspd = pd.read_csv(
+    "s3://asf-heat-pump-affordability/ONSPD_NOV_2024_UK.csv", usecols=["pcd", "ctry"]
+)
+
+# %%
+country_mapping = {
+    "S92000003": "Scotland",
+    "E92000001": "England",
+    "N92000002": "Northern Ireland",
+    "W92000004": "Wales",
+    "L93000001": "Channel Islands",
+    "M83000003": "Isle of Man",
+}
+
+onspd["pcd"] = onspd["pcd"].str.upper().str.replace(r"\s+", "", regex=True)
+onspd["country"] = onspd["ctry"].map(country_mapping)
+
+# %%
+mcs_df["postcode"] = mcs_df["postcode"].str.upper().str.replace(r"\s+", "", regex=True)
+mcs_df = mcs_df.merge(
+    onspd[["pcd", "country"]], how="left", left_on="postcode", right_on="pcd"
+)
+
+# %%
+mcs_df["country"].value_counts(dropna=False)
+
+# %% [markdown]
+# ## Calculate results
+
+# %%
+# UK-wide results
+uk_results = mcs_df["adjusted_cost_band"].value_counts().reset_index()
+uk_results["UK_percentage_of_installations"] = (
+    uk_results["count"] / uk_results["count"].sum() * 100
+).round(2)
+uk_results = uk_results.rename(columns={"count": "UK_ASHP_installation_count"})
+
+# %%
+# Filter to Wales only
+wales_results = mcs_df[mcs_df["country"] == "Wales"]
+wales_results = wales_results["adjusted_cost_band"].value_counts().reset_index()
+wales_results["Wales_percentage_of_installations"] = (
+    wales_results["count"] / wales_results["count"].sum() * 100
+).round(2)
+wales_results = wales_results.rename(columns={"count": "Wales_ASHP_installation_count"})
+
+# %%
+results = wales_results.merge(uk_results, how="left", on="adjusted_cost_band")
+results["adjusted_cost_band"] = pd.Categorical(
+    results["adjusted_cost_band"], categories=choices
+)
+results = results.sort_values(by="adjusted_cost_band")
+results
+
+# %%
+results.to_csv(
+    "s3://asf-heat-pump-affordability/May2022_March2024_ASHP_domestic_installation_costs_2024GBP.csv"
+)

--- a/asf_heat_pump_affordability/pipeline/preprocess_cpi.py
+++ b/asf_heat_pump_affordability/pipeline/preprocess_cpi.py
@@ -17,7 +17,20 @@ def get_df_quarterly_cpi_with_adjustment_factors(
     Returns
         pd.DataFrame: quarterly CPI values with adjustment factors for a given reference year
     """
-    cpi_ref_value = _get_int_ref_cpi_value(ref_year, cpi_df)
+    # TODO - lines 20-24 are TEMP lines to be deleted 15 Jan 2025 when new CPI data released for 2024
+    if ref_year == 2024:
+        cpi_ref_value = cpi_df[
+            (cpi_df["Title"].str.contains(str(ref_year)))
+            & (~cpi_df["Title"].str.contains("Q"))
+        ]
+        cpi_ref_value = (
+            cpi_ref_value[config["cpi_data"]["cpi_column_header"]]
+            .values.astype(float)
+            .mean()
+        )
+        print(f"CPI reference value for 2024: {cpi_ref_value}")
+    else:
+        cpi_ref_value = _get_int_ref_cpi_value(ref_year, cpi_df)
     cpi_quarterly_df = _get_df_quarterly_cpi_data(cpi_df)
     cpi_quarterly_df["adjustment_factor"] = _compute_series_cpi_adjustment_factors(
         ref_cpi=cpi_ref_value, cpi_series=cpi_quarterly_df[cpi_col_header]

--- a/asf_heat_pump_affordability/pipeline/preprocess_cpi.py
+++ b/asf_heat_pump_affordability/pipeline/preprocess_cpi.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import logging
 
 from asf_heat_pump_affordability import config
 
@@ -17,20 +18,8 @@ def get_df_quarterly_cpi_with_adjustment_factors(
     Returns
         pd.DataFrame: quarterly CPI values with adjustment factors for a given reference year
     """
-    # TODO - lines 20-24 are TEMP lines to be deleted 15 Jan 2025 when new CPI data released for 2024
-    if ref_year == 2024:
-        cpi_ref_value = cpi_df[
-            (cpi_df["Title"].str.contains(str(ref_year)))
-            & (~cpi_df["Title"].str.contains("Q"))
-        ]
-        cpi_ref_value = (
-            cpi_ref_value[config["cpi_data"]["cpi_column_header"]]
-            .values.astype(float)
-            .mean()
-        )
-        print(f"CPI reference value for 2024: {cpi_ref_value}")
-    else:
-        cpi_ref_value = _get_int_ref_cpi_value(ref_year, cpi_df)
+    cpi_ref_value = _get_int_ref_cpi_value(ref_year, cpi_df)
+    logging.info(f"CPI reference value for year {ref_year}: {cpi_ref_value}")
     cpi_quarterly_df = _get_df_quarterly_cpi_data(cpi_df)
     cpi_quarterly_df["adjustment_factor"] = _compute_series_cpi_adjustment_factors(
         ref_cpi=cpi_ref_value, cpi_series=cpi_quarterly_df[cpi_col_header]


### PR DESCRIPTION
Fixes #28 

# Description

This notebook fulfils a data request from ASF team for a breakdown of the costs of domestic installations of heat pumps, in cost brackets, with a distribution of installations (number and percentage if possible) across these cost brackets since the launch of BUS, in Wales and in the UK (since May 2022).

Note: I had to make a temporary change to `asf_heat_pump_affordability/pipeline/preprocess_cpi.py` to calculate 2024 CPI reference value. It temporarily calculates an average CPI for 2024 from 11 months of data (Jan-Nov). According to the documentation of the source data, the next release is on 15 Jan 2025. So we should be able to remove the temporary lines (indicated) and re-run with full 2024 data.

# Instructions for Reviewer

In order to test the code in this PR you need to ...
To generate the notebook, make sure `jupytext` is installed, then run:
`jupytext --to notebook asf_heat_pump_suitability/notebooks/cost_brackets_ASHPs.py`

You can then run the notebook as usual.

The output file is listed below if you want to load and check that:
`s3://asf-heat-pump-affordability/May2022_March2024_ASHP_domestic_installation_costs_2024GBP.csv`

Please pay special attention to ...
- Temporary code change to calculate CPI reference value. Is that an appropriate interim calculation?
- Results seem sensible
- Appropriate selection criteria are applied to MCS records to create analytical sample

I'm not sure about the cost brackets but I think that really depends on what the data would be used to demonstrate and isn't necessarily for us to choose. Once reviewed, we can show the results to the team and they can let us know if they need a different distribution.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
